### PR TITLE
Fix the file watcher

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,6 +72,30 @@ new class App {
     app.on('before-quit', () => this.shouldQuitApp = true)
   }
 
+  copyFile (from, to) {
+    return new Promise((resolve, reject) => {
+      let readStream = fs.createReadStream(from)
+      let writeStream = fs.createWriteStream(to)
+
+      readStream.on('error', error => {
+        log.error('Error reading screenshot file:', error)
+        reject(error)
+      })
+
+      writeStream.on('error', error => {
+        log.error('Error copying screenshot file:', error)
+        reject(error)
+      })
+
+      writeStream.on('close', () => {
+        log.info('Copied screenshot to temp directory')
+        resolve()
+      })
+
+      readStream.pipe(writeStream)
+    })
+  }
+
   createPane () {
     this.pane = new BrowserWindow({
       frame: false,
@@ -148,22 +172,35 @@ new class App {
   }
 
   handleScreenshot (filename) {
-    let scpConfig = this.getSCPConfig()
+    log.info('Handling screenshot')
+
     let filepath = path.resolve(this.screenshotFolder, filename)
     let fileExt = path.extname(filename)
     let hashedFilename = `${shorthash.unique(filename.replace(fileExt, ''))}${fileExt}`
     let hashedFilepath = path.resolve(app.getPath('temp'), hashedFilename)
     let shortlink = this.generateShortlink(hashedFilename)
 
-    fs.renameSync(filepath, hashedFilepath)
+    try {
+      fs.readFileSync(filepath)
+    } catch (error) {
+      log.error('Failed to read file. Aborting.')
+      return
+    }
 
-    this.uploadFile(hashedFilepath, scpConfig, this.getPrivateKeys())
+    log.info(`A screenshot was captured at ${filename.replace('Screen Shot ', '').replace('.png', '')}`)
+
+    this.copyFile(filepath, hashedFilepath)
+    .then(() => {
+      if (this.config.get('deleteAfterUpload')) {
+        fs.unlinkSync(filepath)
+      }
+
+      this.uploadFile(hashedFilepath)
+    })
   }
 
   initialize () {
-
-
-
+    log.info('Initializing app')
 
     let trayIconPath
 
@@ -215,6 +252,8 @@ new class App {
 
     // Start listening for screenshots to be taken
     this.startScreenshotListener()
+
+    log.info('App initialized')
   }
 
   setupApplicationMenu () {
@@ -253,7 +292,7 @@ new class App {
   startScreenshotListener () {
     // MacOS
     fs.watch(this.screenshotFolder, (type, filename) => {
-      if (type === 'change' && filename.indexOf('Screen Shot') === 0) {
+      if (filename.indexOf('Screen Shot') === 0) {
         this.handleScreenshot(filename)
       }
     })
@@ -264,37 +303,21 @@ new class App {
   //  })
   }
 
-  uploadFile (filepath, scpConfig, privateKeys = []) {
-    let shortlink = this.generateShortlink(path.basename(filepath))
+  uploadFile (filepath) {
+    let filename = path.basename(filepath)
+    let privateKeys = this.getPrivateKeys()
+    let scpConfig = this.getSCPConfig()
+    let shortlink = this.generateShortlink(filename)
 
-    if (!scpConfig.password) {
-      for (let i = 0, length = privateKeys.length; i < length; i++) {
-        let privateKey = privateKeys.shift()
+    log.info('Uploading file', filename)
 
-        scpConfig.privateKey = privateKey
+    let keysToTry = scpConfig.password ? 1 : privateKeys.length
 
-        scpClient.scp(filepath, scpConfig, error => {
-          if (error) {
-            if (privateKeys.length) {
-              return this.uploadFile(filepath, scpConfig, privateKeys)
-            }
-
-            return log.error('Upload error:', error)
-          }
-
-          log.info('Upload success!')
-
-          fs.unlinkSync(filepath)
-
-          clipboard.writeText(shortlink)
-
-          notify('Screenshot uploaded!', {
-            body: 'The screenshot URL has been copied to your clipboard.'
-          })
-        })
+    for (let i = 0; i < keysToTry; i++) {
+      if (!scpConfig.password) {
+        scpConfig.privateKey = privateKeys[i]
       }
 
-    } else {
       scpClient.scp(filepath, scpConfig, error => {
         if (error) {
           if (privateKeys.length) {
@@ -303,8 +326,6 @@ new class App {
 
           return log.error('Upload error:', error)
         }
-
-        fs.unlinkSync(filepath)
 
         log.info('Upload success!')
 


### PR DESCRIPTION
The filewatcher wasn't always capturing the screen shots because the events weren't always fired as `change` events. Now we don't care what kind of event it is, but we'll bail if the file isn't readable in case of renames and such.

* Bail before attempting to copy or upload if the file is no longer readable
* Refactor `uploadFile` method to DRY it up. Like... a lot.
* Add `copyFile` method
  * `copyFile` makes a copy of the screen shot in the temp directory instead of moving/renaming it
  * `handleScreenshot` now checks for a `deleteAfterUpload` config before deleting the original file
* This commit is waaaaaaaay too big